### PR TITLE
Fix the name issue for GreaterThanEquals

### DIFF
--- a/aws-step-functions.js
+++ b/aws-step-functions.js
@@ -105,7 +105,7 @@ Draw.loadPlugin(function(ui) {
       "<": "LessThan",
       ">": "GreaterThan",
       "<=": "LessThanEquals",
-      ">=": "GreatherThanEquals"
+      ">=": "GreaterThanEquals"
     },
     parseJSEPObject: function (obj, res){
       if (res == null)


### PR DESCRIPTION
When I export Json for my step function in draw.io, AWS will throw an error: There is a problem with your ASL definition, please review it and try again. I found that it was caused by spelling mistake.