### PR TITLE
fix: a blank export window on draw.io desktop

### DIFF
--- a/aws-step-functions.js
+++ b/aws-step-functions.js
@@ -1684,13 +1684,13 @@ Draw.loadPlugin(function(ui) {
   ui.actions.addAction('awssfExportJSON', function()
   {
     var data = getStepFunctionDefinition();
-    mxUtils.popup(JSON.stringify(data, null, "  "));
+    mxUtils.popup(JSON.stringify(data, null, "  "), true);
   });
 
   ui.actions.addAction('awssfExportYAML', function()
   {
     var data = getStepFunctionDefinition();
-    mxUtils.popup(jsyaml.dump(data));
+    mxUtils.popup(jsyaml.dump(data), true);
   });
 
   ui.actions.addAction('awssfExport', function()


### PR DESCRIPTION
#4 change popup type to support draw.io Desktop.